### PR TITLE
feat: add notebook to convert to any file

### DIFF
--- a/notebooks/5_warc2any.ipynb
+++ b/notebooks/5_warc2any.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "710a540b",
+   "metadata": {},
+   "source": [
+    "### *Requirements*\n",
+    "*To use this notebook, you need a WARC export of your search result from SolrWayback. (See **[SolrWayback > Export](https://nlnwa.github.io/research-services/docs/solrwayback/solrwayback-5export.html)** )*\n",
+    "\n",
+    "*We also recommend to give it a meaningful name, e.g. `domain-regjeringen-no_content-type-html.warc`*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ba0a5dc",
+   "metadata": {},
+   "source": [
+    "# WARC to any\n",
+    "This notebook allow you to extract any underlying file(s) from warc records."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95b531bc",
+   "metadata": {},
+   "source": [
+    "## Import packages\n",
+    "Before starting, we must import the necessary python libraries.\n",
+    "\n",
+    "To run a code cell: Make sure it is marked and then press <kbd>Shift</kbd> + <kbd>Enter</kbd>)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a93c902a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from mimetypes import guess_extension\n",
+    "\n",
+    "from warcio import ArchiveIterator\n",
+    "from warcio.archiveiterator import ArchiveIterator\n",
+    "\n",
+    "from magic import detect_from_content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9023df73",
+   "metadata": {},
+   "source": [
+    "## Set WARC file path and output directory\n",
+    "First, we need to set the path and file name we want to extract from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c7815bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "warc_path = Path().home() / \"Downloads\"/ \"<insert-name-here>\" # it will likely look something like this: solrwayback_2023-09-05_08-39-11.warc.gz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1c5aa3a",
+   "metadata": {},
+   "source": [
+    "Then, we define where the HTML files should be output to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4992a26a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repo_root = (Path() / \"..\" ).resolve()\n",
+    "output_root_dir = repo_root / \"output\"\n",
+    "output_root_dir.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e32d2c",
+   "metadata": {},
+   "source": [
+    "## Open WARC and extract files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "563e4b4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _write_output(file_extension: str) -> None:\n",
+    "    output_dir = output_root_dir / file_extension[1:]\n",
+    "    output_dir.mkdir(parents=True, exist_ok=True)\n",
+    "    destination = (output_dir / f\"{warc_record_id}{file_extension}\")\n",
+    "    destination.write_bytes(payload)\n",
+    "     \n",
+    "\n",
+    "# Open the WARC file and iterate through its records\n",
+    "with open(warc_path, \"rb\") as file_pointer:\n",
+    "    for record in ArchiveIterator(file_pointer):\n",
+    "        if record.rec_type != \"response\":\n",
+    "            continue\n",
+    "        warc_record_id = record.rec_headers.get_header(\"WARC-Record-ID\")\n",
+    "        warc_record_id = warc_record_id.replace(\"<\", \"\").replace(\">\", \"\").replace(\":\", \"_\")\n",
+    "        payload = record.content_stream().read()\n",
+    "        detected_mime_type = detect_from_content(payload)\n",
+    "        failed_to_obtain_file_extension = False\n",
+    "        if guess_extension(detected_mime_type.mime_type) is None:\n",
+    "            failed_to_obtain_file_extension = True\n",
+    "            print(f\"Failed to detect file extension from mime type '{detected_mime_type.mime_type}', using provided mime type '{record.http_headers.get_header('Content-Type')}' instead\")\n",
+    "            provided_mime_type = record.http_headers.get_header('Content-Type')\n",
+    "        try:\n",
+    "            if failed_to_obtain_file_extension:\n",
+    "                _write_output(guess_extension(provided_mime_type))\n",
+    "            else:\n",
+    "                _write_output(guess_extension(detected_mime_type.mime_type))\n",
+    "        except TypeError:\n",
+    "            print(f\"Failed to determine type of '{record.rec_headers.get_header('WARC-Record-ID')}'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6ec18b3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Motivation

It can be very interesting to see the resources scraped from a website downloaded locally, so that the end-user can use them for various purposes.

Notebook 4 is only able to write `HTML` to disk, while the notebook used in this commit is able to write most Multipurpose Internet Mail Extensions or `MIME` types to disk.

# Implementation

The file content is written to disk by first guessing the `MIME` type from the content. The reason why we do this is that some websites use the wrong `MIME` type, so it seems to be safer to detect the type using `magic`.

If the detected type does not have a file extension, we try to get the file extension using the provided `MIME` type instead as a last resort.

If this also fails we just give up and print a warning.