### PR TITLE
feat: build corpus and analyse text with dhlab api

### DIFF
--- a/notebooks/nettavis-tekstanalyse-v0-2.ipynb
+++ b/notebooks/nettavis-tekstanalyse-v0-2.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "05de1daf-8e8d-4fda-9f94-ee14b50136fa",
+   "metadata": {},
+   "source": [
+    "*NB: Denne notebooken er i utvikling, og ment som et eksempel på hvordan brukere kan jobbe programmatisk med nettavis-korpuset. Har du spørsmål eller tilbakemeldinger, kontakt [nettarkivet@nb.no](mailto:nettarkivet@nb.no)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b09cfab3-b087-4c99-9d81-62964a58d2ca",
+   "metadata": {},
+   "source": [
+    "## Importer `dhlab` for python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a610b652-da43-4f84-b13c-77cb5ded0444",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install -U dhlab (fjern `#` for å installere siste versjon av python-pakka for dhlab\n",
+    "import dhlab as dh\n",
+    "import dhlab.nbtext as nb\n",
+    "from dhlab import Corpus, totals, Collocations, Ngram"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb70b1a3-106c-42f2-b711-a626ffb5b5fa",
+   "metadata": {},
+   "source": [
+    "# Korpusanalyse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc1c9b6c-392b-4d21-9238-82f80c0167b2",
+   "metadata": {},
+   "source": [
+    "Et korpus betyr en samling av tekster. I denne sammenhengen bygger vi korpus med tekster fra norske nettaviser mellom 2019-2022, angitt med `doctype=\"nettavis\"`.\n",
+    "\n",
+    "I `dhlab` brukes Python-klassen `Corpus` til å representere en liste med metadata om hvert dokument. Her finner du blant annet metadata som publikasjonstittel, språk, dato for innhøsting, domenenavn, osv. Tekstene i korpuset har også en unik `dhlabid`, som er DHlabs persistente URN.\n",
+    "\n",
+    "For en liste over de ulike attributene som eksponeres gjennom APIet, se denne artikkelen om [Korpus med nettaviser](https://www.nb.no/samlingen/nettarkivet/forskning/korpus-med-nettaviser/#hvilke-skjema-attributter-kan-jeg-benytte-mot-apiet?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b50169cc-7642-42c3-9026-c924f6b65566",
+   "metadata": {},
+   "source": [
+    "## 1. Bygge korpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1041f2ea-6e94-464a-9de7-51272ca6848d",
+   "metadata": {},
+   "source": [
+    "La oss bygge et korpus!\n",
+    "\n",
+    "Kodecellen under bygger et korpus med tekster fra NRK som inneholder ord som begynner på \"vindmølle*\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcdc8f15-cd61-44ab-b4d8-4a9c3d45119c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corpus = dh.Corpus(doctype=\"nettavis\", title=\"NRK\", fulltext=\"vindmølle*\", limit=100000)\n",
+    "corpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b87c3df6-02b5-474a-ac9d-cc094a461b35",
+   "metadata": {},
+   "source": [
+    "### Eksportere korpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ec42cc1-50ca-42b5-b9b6-cc9b81485b9d",
+   "metadata": {},
+   "source": [
+    "Hvis du vil lagre resultatene kan du eksportere dem i Excel og/eller JSONL format. Husk å endre filnavnet og ev. filsti!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f432435-b867-4b11-ab20-dca23dec297a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Eksporter korpus til Excel (endre filnavn og filsti)\n",
+    "corpus.frame.to_excel('./korpus-vindmølle.xlsx', index=False)\n",
+    "\n",
+    "# Eksportere korpus til JSONL (endre filnavn og filsti)\n",
+    "corpus.frame.to_json('./korpus-vindmølle.jsonl', orient='records', lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "efd768d9-d975-47ea-b2e2-8e435acd436a",
+   "metadata": {},
+   "source": [
+    "## 2. Konkordanser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd4652ee-8106-4384-9886-832c2923f774",
+   "metadata": {},
+   "source": [
+    "Når du har bygget korpuset kan du hente ut ulike informasjon om korpuset.\n",
+    "\n",
+    "Kodecellen under henter ut konkordanser, det vil si et tekstvindu med inntil 12 ord før/etter et søkeord. Søkeordet fremheves i fet skrift.\n",
+    "\n",
+    "La oss be om konkordanser for ordet \"vindmølle\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e56b9211-dbea-4490-82f6-8696aeb4d3e0",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "conc_windmill = corpus.conc(words=\"vindmølle*\")\n",
+    "conc_windmill.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71cd054d-1743-40ef-be2e-298ad5897345",
+   "metadata": {},
+   "source": [
+    "### Eksportere konkordanser"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45af6a29-c073-48a9-b505-eaf704532c08",
+   "metadata": {},
+   "source": [
+    "Hvis du vil lagre resultatene kan du eksportere dem i Excel og/eller JSONL format. Husk å endre filnavnet og ev. filsti!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c00ae65-d510-46ad-a81b-7cbebacd6e0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Eksportere konkordanser til Excel\n",
+    "conc_windmill.frame.to_excel('./konkordanser-vindmølle.xlsx', index=False)\n",
+    "\n",
+    "# Eksportere konkordanser til JSONL\n",
+    "conc_windmill.frame.to_json('./konkordanser-vindmølle.jsonl', orient='records', lines=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5996ff6b-8c0c-4cf5-9c58-7144e9bae006",
+   "metadata": {},
+   "source": [
+    "## 3. Kollokasjoner og ordfrekvenser\n",
+    "Kollokasjoner er ordpar som forekommer sammen. Ved å telle kollokasjoner for et gitt ord kan vi si noe om frekvensen for hvor hyppig/sjelden ulike ord forekommer sammen med hverandre.\n",
+    "\n",
+    "En del ord alltid vil forekomme hyppig i alle tekster, slik som `og`, `han` og `hun`. For å finne ord som er signifikante innen en gitt kontekst kan vi beregne en relativfrekvens, der vi sammenlikner frekvensen i vårt eget korpus med et allment referansekorpus.\n",
+    "\n",
+    "Cellen under lister ordene med høyest relativfrekvens, gitt et nøkkelord i korpuset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8a6916f-a88f-46fd-b15c-fe4e21f9b7d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tot = totals(50000) # Henter referansekorpus for å sammenlikne relativfrekvens\n",
+    "coll = corpus.coll(\"vindmøller\").frame.sort_values(by=\"counts\", ascending=False) # Teller kollokasjoner for nøkkelord i korpuset\n",
+    "(coll.counts / tot.freq).sort_values(ascending = False).head(20) # Finner relativfrekvens i korpuset, sammenliknet med referansekorpuset"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Experimental notebook utilising the web news corpus via api.nb.no/dhlab.

Main features:
- build corpus,
- get concordances,
- get collocations
- calculate the relative frequency of collocated words